### PR TITLE
Fix timestamp format in Python logger client

### DIFF
--- a/docs_tofupilot/integrations/openhtf/main.py
+++ b/docs_tofupilot/integrations/openhtf/main.py
@@ -7,7 +7,9 @@ def phase_one():
 
 
 def main():
-    test = htf.Test(phase_one, procedure_id="FVT1", part_number="PCB01") # Specify procedure and part_number
+    test = htf.Test(
+        phase_one, procedure_id="FVT1", part_number="PCB01"
+    )  # Specify procedure and part_number
 
     with TofuPilot(test):  # One-line integration
         test.execute(lambda: "PCB1A001")

--- a/docs_tofupilot/logger/client/main.py
+++ b/docs_tofupilot/logger/client/main.py
@@ -1,17 +1,21 @@
 import logging
 import sys
+from datetime import datetime
 from tofupilot import TofuPilotClient
 
 
-class JsonCaptureHandler(logging.Handler):
+class TofuPilotLogHandler(logging.Handler):
+    """Handler that captures logs in a format compatible with TofuPilot API."""
+    
     def __init__(self):
         super().__init__()
         self.logs = []
 
     def emit(self, record):
+        # Format log with ISO-8601 timestamp (millisecond precision) for TofuPilot API
         log_entry = {
             "level": record.levelname,
-            "timestamp": int(record.created * 1000),
+            "timestamp": f"{datetime.fromtimestamp(record.created).isoformat(timespec='milliseconds')}Z",
             "message": record.getMessage(),
             "source_file": record.filename,
             "line_number": record.lineno,
@@ -19,25 +23,28 @@ class JsonCaptureHandler(logging.Handler):
         self.logs.append(log_entry)
 
 
-# Initialize the TofuPilot client.
+# Initialize the TofuPilot client to report test results
 client = TofuPilotClient()
 
-# Set up local logger
+# Set up local logger with custom name and prevent propagation to parent loggers
 local_logger = logging.getLogger("test_logger")
 local_logger.setLevel(logging.DEBUG)
-local_logger.propagate = (
-    False  # if we don't want to propagate to the parent/root logger
-)
+local_logger.propagate = False
 
-capture_handler = JsonCaptureHandler()
-output_handler = logging.StreamHandler(sys.stdout)
+# Add handlers: one for TofuPilot API capture and one for console output
+capture_handler = TofuPilotLogHandler()
 local_logger.addHandler(capture_handler)
-local_logger.addHandler(output_handler)
+local_logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
-local_logger.warning("This is a log we want to keep.")
+# Log examples at different severity levels
+local_logger.debug("Debug message: Detailed information for troubleshooting")
+local_logger.info("Info message: Normal operation information")
+local_logger.warning("Warning: Something unexpected but not critical")
+local_logger.error("Error: A significant problem that needs attention")
+local_logger.critical("Critical: System unstable, immediate action required")
 
-# Create a run and send logs
+# Create a run and send captured logs to TofuPilot
 try:
     client.create_run(
         procedure_id="FVT1",

--- a/docs_tofupilot/logger/client/main.py
+++ b/docs_tofupilot/logger/client/main.py
@@ -1,18 +1,20 @@
 import logging
 import sys
 from datetime import datetime
+
 from tofupilot import TofuPilotClient
 
 
 class TofuPilotLogHandler(logging.Handler):
     """Handler that captures logs in a format compatible with TofuPilot API."""
-    
+
     def __init__(self):
         super().__init__()
         self.logs = []
 
     def emit(self, record):
-        # Format log with ISO-8601 timestamp (millisecond precision) for TofuPilot API
+        # Format log with ISO-8601 timestamp (millisecond precision) for
+        # TofuPilot API
         log_entry = {
             "level": record.levelname,
             "timestamp": f"{datetime.fromtimestamp(record.created).isoformat(timespec='milliseconds')}Z",
@@ -26,7 +28,8 @@ class TofuPilotLogHandler(logging.Handler):
 # Initialize the TofuPilot client to report test results
 client = TofuPilotClient()
 
-# Set up local logger with custom name and prevent propagation to parent loggers
+# Set up local logger with custom name and prevent propagation to parent
+# loggers
 local_logger = logging.getLogger("test_logger")
 local_logger.setLevel(logging.DEBUG)
 local_logger.propagate = False

--- a/docs_tofupilot/measurements/boolean/client/main.py
+++ b/docs_tofupilot/measurements/boolean/client/main.py
@@ -1,6 +1,7 @@
-from datetime import datetime
-from tofupilot import MeasurementOutcome, PhaseOutcome, TofuPilotClient
 import random
+from datetime import datetime
+
+from tofupilot import MeasurementOutcome, PhaseOutcome, TofuPilotClient
 
 client = TofuPilotClient()
 
@@ -34,7 +35,8 @@ def main():
         procedure_id="FVT1",  # Create the procedure first in the Application
         unit_under_test={"serial_number": "PCB1A001", "part_number": "PCB1"},
         phases=phases,
-        run_passed=all(phase["outcome"] == PhaseOutcome.PASS for phase in phases),
+        run_passed=all(
+            phase["outcome"] == PhaseOutcome.PASS for phase in phases),
     )
 
 

--- a/docs_tofupilot/measurements/dimensional/client/main.py
+++ b/docs_tofupilot/measurements/dimensional/client/main.py
@@ -1,6 +1,7 @@
-from datetime import datetime
-from tofupilot import MeasurementOutcome, PhaseOutcome, TofuPilotClient
 import random
+from datetime import datetime
+
+from tofupilot import MeasurementOutcome, PhaseOutcome, TofuPilotClient
 
 client = TofuPilotClient()
 
@@ -14,7 +15,8 @@ def phase_voltage_measure():
         voltage = round(random.uniform(3.3, 3.5), 2)
         current = round(random.uniform(0.3, 0.8), 3)
         resistance = voltage / current
-        structured_measurements.append((timestamp, voltage, current, resistance))
+        structured_measurements.append(
+            (timestamp, voltage, current, resistance))
 
     phase = [
         {
@@ -43,7 +45,8 @@ def main():
         procedure_id="FVT1",  # Create the procedure first in the Application
         unit_under_test={"serial_number": "PCB1A001", "part_number": "PCB1"},
         phases=phases,
-        run_passed=all(phase["outcome"] == PhaseOutcome.PASS for phase in phases),
+        run_passed=all(
+            phase["outcome"] == PhaseOutcome.PASS for phase in phases),
     )
 
 

--- a/docs_tofupilot/measurements/dimensional/openhtf/main.py
+++ b/docs_tofupilot/measurements/dimensional/openhtf/main.py
@@ -1,7 +1,8 @@
+import random
+
 import openhtf as htf
 from openhtf.util import units
 from tofupilot.openhtf import TofuPilot
-import random
 
 
 @htf.measures(

--- a/docs_tofupilot/measurements/multi-measurements/client/main.py
+++ b/docs_tofupilot/measurements/multi-measurements/client/main.py
@@ -1,6 +1,7 @@
 import random
 from datetime import datetime
-from tofupilot import TofuPilotClient, PhaseOutcome, MeasurementOutcome
+
+from tofupilot import MeasurementOutcome, PhaseOutcome, TofuPilotClient
 
 client = TofuPilotClient()
 

--- a/docs_tofupilot/measurements/multi-measurements/openhtf/main.py
+++ b/docs_tofupilot/measurements/multi-measurements/openhtf/main.py
@@ -1,14 +1,16 @@
+import random
+
 import openhtf as htf
 from openhtf.util import units
 from tofupilot.openhtf import TofuPilot
-import random
 
 
 @htf.measures(
     htf.Measurement("is_connected").equals(True),  # Boolean measure
     htf.Measurement("firmware_version").equals("1.2.7"),  # String measure
     htf.Measurement("input_voltage").in_range(3.2, 3.4).with_units(units.VOLT),
-    htf.Measurement("input_current").in_range(maximum=1.5).with_units(units.AMPERE),
+    htf.Measurement("input_current").in_range(
+        maximum=1.5).with_units(units.AMPERE),
 )
 def phase_multi_measurements(test):
     test.measurements.is_connected = True

--- a/docs_tofupilot/measurements/numerical/client/main.py
+++ b/docs_tofupilot/measurements/numerical/client/main.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+
 from tofupilot import MeasurementOutcome, PhaseOutcome, TofuPilotClient
 
 client = TofuPilotClient()
@@ -36,7 +37,8 @@ def main():
         procedure_id="FVT1",  # Create the procedure first in the Application
         unit_under_test={"serial_number": "PCB1A001", "part_number": "PCB1"},
         phases=phases,
-        run_passed=all(phase["outcome"] == PhaseOutcome.PASS for phase in phases),
+        run_passed=all(
+            phase["outcome"] == PhaseOutcome.PASS for phase in phases),
     )
 
 

--- a/docs_tofupilot/measurements/string/client/main.py
+++ b/docs_tofupilot/measurements/string/client/main.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+
 from tofupilot import MeasurementOutcome, PhaseOutcome, TofuPilotClient
 
 client = TofuPilotClient()
@@ -33,7 +34,8 @@ def main():
         procedure_id="FVT1",  # Create the procedure first in the Application
         unit_under_test={"serial_number": "PCB1A001", "part_number": "PCB1"},
         phases=phases,
-        run_passed=all(phase["outcome"] == PhaseOutcome.PASS for phase in phases),
+        run_passed=all(
+            phase["outcome"] == PhaseOutcome.PASS for phase in phases),
     )
 
 

--- a/docs_tofupilot/phases/advanced/openhtf/main.py
+++ b/docs_tofupilot/phases/advanced/openhtf/main.py
@@ -16,9 +16,11 @@ def phase_firmware_version_check(test):
 
 # Phase with multiple measurements
 @htf.measures(
-    htf.Measurement("input_voltage").in_range(3.1, 3.5).with_units(units.VOLT),
-    htf.Measurement("output_voltage").in_range(1.1, 1.3).with_units(units.VOLT),
-)
+    htf.Measurement("input_voltage").in_range(
+        3.1, 3.5).with_units(
+            units.VOLT), htf.Measurement("output_voltage").in_range(
+                1.1, 1.3).with_units(
+                    units.VOLT), )
 def phase_voltage_measurements(test):
     test.measurements.input_voltage = 3.3
     test.measurements.output_voltage = 1.2

--- a/docs_tofupilot/phases/optional/client/main.py
+++ b/docs_tofupilot/phases/optional/client/main.py
@@ -36,9 +36,7 @@ def main():
 
     client.create_run(
         procedure_id="FVT1",  # Create the procedure first in the Application
-        unit_under_test={
-            "serial_number": "PCB1A001",
-            "part_number": "PCB1"},
+        unit_under_test={"serial_number": "PCB1A001", "part_number": "PCB1"},
         phases=phases,
         run_passed=all(
             phase["outcome"] == PhaseOutcome.PASS for phase in phases),

--- a/docs_tofupilot/phases/required/client/main.py
+++ b/docs_tofupilot/phases/required/client/main.py
@@ -22,9 +22,7 @@ def main():
 
     client.create_run(
         procedure_id="FVT1",  # Create the procedure first in the Application
-        unit_under_test={
-            "serial_number": "PCB1A001",
-            "part_number": "PCB1"},
+        unit_under_test={"serial_number": "PCB1A001", "part_number": "PCB1"},
         phases=phases,
         run_passed=all(
             phase["outcome"] == PhaseOutcome.PASS for phase in phases),

--- a/docs_tofupilot/procedures/client/main.py
+++ b/docs_tofupilot/procedures/client/main.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+
 from tofupilot import TofuPilotClient
 
 

--- a/docs_tofupilot/stations/client/main.py
+++ b/docs_tofupilot/stations/client/main.py
@@ -1,10 +1,12 @@
 # Before running the script, ensure you have created a station in the TofuPilot interface
 # and linked it to the specified procedure ID ("FVT1" in this example).
 # You also need to save your API key in an environment variable named "STATION_API_KEY"
-# or pass it directly as an argument like this: TofuPilotClient(api_key="STATION_API_KEY")
+# or pass it directly as an argument like this:
+# TofuPilotClient(api_key="STATION_API_KEY")
 
-from datetime import timedelta, datetime
-from tofupilot import TofuPilotClient, PhaseOutcome
+from datetime import datetime, timedelta
+
+from tofupilot import PhaseOutcome, TofuPilotClient
 
 
 def phase_one():
@@ -26,7 +28,8 @@ def main():
 
     client.create_run(
         procedure_id="FVT1",  # Create a station in TofuPilot linked to this procedure ID
-        run_passed=all(phase["outcome"] == PhaseOutcome.PASS for phase in phases),
+        run_passed=all(
+            phase["outcome"] == PhaseOutcome.PASS for phase in phases),
         unit_under_test={"serial_number": "PCB1A001", "part_number": "PCBA01"},
         phases=phases,
         duration=timedelta(minutes=1, seconds=45),

--- a/docs_tofupilot/stations/openhtf/main.py
+++ b/docs_tofupilot/stations/openhtf/main.py
@@ -1,7 +1,8 @@
 # Before running the script, ensure you have created a station in the TofuPilot interface
 # and linked it to the specified procedure ID ("FVT1" in this example).
 # You also need to save your API key in an environment variable named "STATION_API_KEY"
-# or pass it directly as an argument like this: TofuPilot(test, api_key="STATION_API_KEY")
+# or pass it directly as an argument like this: TofuPilot(test,
+# api_key="STATION_API_KEY")
 
 
 import openhtf as htf

--- a/docs_tofupilot/sub-units/client/main.py
+++ b/docs_tofupilot/sub-units/client/main.py
@@ -12,7 +12,8 @@ def main():
         procedure_id="FVT2",  # Create the procedure first in the Application
         unit_under_test={"serial_number": "CAM1A001", "part_number": "CAM1"},
         run_passed=True,
-        sub_units=[{"serial_number": "PCB1A001"}, {"serial_number": "LEN1A001"}],
+        sub_units=[{"serial_number": "PCB1A001"},
+                   {"serial_number": "LEN1A001"}],
     )
 
 

--- a/docs_tofupilot/sub-units/openhtf/main.py
+++ b/docs_tofupilot/sub-units/openhtf/main.py
@@ -10,7 +10,8 @@ def main():
     test = Test(
         procedure_id="FVT2",  # Create the procedure first in the Application
         part_number="CAM1",
-        sub_units=[{"serial_number": "PCB1A001"}, {"serial_number": "LEN1A001"}],
+        sub_units=[{"serial_number": "PCB1A001"},
+                   {"serial_number": "LEN1A001"}],
     )
     with TofuPilot(test):
         test.execute(lambda: "CAM1A001")

--- a/qa/client/create_run/basic/main.py
+++ b/qa/client/create_run/basic/main.py
@@ -8,8 +8,9 @@ Ensure your API key is stored in the environment variables as per the documentat
 https://tofupilot.com/docs/user-management#api-key
 """
 
-from tofupilot import TofuPilotClient
 import random
+
+from tofupilot import TofuPilotClient
 
 
 def main():
@@ -21,7 +22,9 @@ def main():
     serial_number = f"00220D4K{random_digits}"
     client.create_run(
         procedure_id="FVT1",
-        unit_under_test={"serial_number": serial_number, "part_number": "PCB01"},
+        unit_under_test={
+            "serial_number": serial_number,
+            "part_number": "PCB01"},
         run_passed=True,
     )
 

--- a/qa/client/create_run/phases_string_outcome/main.py
+++ b/qa/client/create_run/phases_string_outcome/main.py
@@ -1,5 +1,6 @@
 import random
 import time
+
 from tofupilot import TofuPilotClient
 
 client = TofuPilotClient()

--- a/qa/client/create_run/procedure_version/main.py
+++ b/qa/client/create_run/procedure_version/main.py
@@ -1,6 +1,7 @@
 import random
 import time
 from datetime import datetime, timedelta
+
 from tofupilot import TofuPilotClient
 
 

--- a/qa/client/create_run/started_at/main.py
+++ b/qa/client/create_run/started_at/main.py
@@ -1,6 +1,7 @@
-from tofupilot import TofuPilotClient
 import random
 from datetime import datetime, timedelta
+
+from tofupilot import TofuPilotClient
 
 
 def main():
@@ -12,10 +13,15 @@ def main():
     serial_number = f"00220D4K{random_digits}"
     client.create_run(
         procedure_id="FVT1",
-        unit_under_test={"serial_number": serial_number, "part_number": "PCB01"},
+        unit_under_test={
+            "serial_number": serial_number,
+            "part_number": "PCB01"},
         run_passed=True,
-        started_at=datetime.now() - timedelta(days=1),
-        duration=timedelta(seconds=23),
+        started_at=datetime.now() -
+        timedelta(
+            days=1),
+        duration=timedelta(
+            seconds=23),
     )
 
 

--- a/qa/openhtf/generic/main.py
+++ b/qa/openhtf/generic/main.py
@@ -1,6 +1,7 @@
 import random
 import time
 from datetime import datetime, timedelta
+
 import openhtf as htf
 from openhtf.util import units
 from tofupilot.openhtf import TofuPilot
@@ -17,7 +18,8 @@ def check_button(test):
     time.sleep(1)
 
 
-@htf.measures(htf.Measurement("input_voltage").in_range(4.5, 5).with_units(units.VOLT))
+@htf.measures(htf.Measurement("input_voltage").in_range(4.5,
+              5).with_units(units.VOLT))
 def test_voltage_input(test):
     test.measurements.input_voltage = round(random.uniform(3.7, 4.9), 2)
 
@@ -35,7 +37,8 @@ def test_voltage_output(test):
     .with_units(units.AMPERE)
 )
 def test_overcurrent_protection(test):
-    test.measurements.current_protection_triggered = round(random.uniform(1.0, 1.7), 3)
+    test.measurements.current_protection_triggered = round(
+        random.uniform(1.0, 1.7), 3)
     time.sleep(1)
 
 
@@ -52,7 +55,8 @@ def test_battery_switch():
 def test_converter_efficiency(test):
     input_power = 500
     output_power = round(random.uniform(425, 480))
-    test.measurements.efficiency = round(((output_power / input_power) * 100), 1)
+    test.measurements.efficiency = round(
+        ((output_power / input_power) * 100), 1)
     time.sleep(1)
 
 

--- a/qa/openhtf/logger/main.py
+++ b/qa/openhtf/logger/main.py
@@ -1,7 +1,8 @@
-import openhtf as htf
-from tofupilot.openhtf import TofuPilot
-from openhtf.output.callbacks import json_factory
 import random
+
+import openhtf as htf
+from openhtf.output.callbacks import json_factory
+from tofupilot.openhtf import TofuPilot
 
 
 @htf.measures(htf.Measurement("button_status").equals(True))
@@ -40,7 +41,9 @@ def main():
     random_digits = "".join([str(random.randint(0, 9)) for _ in range(5)])
     serial_number = f"00220D4K{random_digits}"
 
-    test.add_output_callbacks(json_factory.OutputToJSON("test_result.json", indent=2))
+    test.add_output_callbacks(
+        json_factory.OutputToJSON(
+            "test_result.json", indent=2))
 
     # Execute the test
     with TofuPilot(test):

--- a/qa/openhtf/multi_dimensions/main.py
+++ b/qa/openhtf/multi_dimensions/main.py
@@ -1,10 +1,11 @@
-import openhtf as htf
-from openhtf.util import units
-from tofupilot.openhtf import TofuPilot
-from openhtf.output.callbacks import json_factory
 import random
 import time
+
 import numpy as np
+import openhtf as htf
+from openhtf.output.callbacks import json_factory
+from openhtf.util import units
+from tofupilot.openhtf import TofuPilot
 
 
 @htf.measures(
@@ -65,7 +66,8 @@ def power_phase(test):
         voltage = round(random.uniform(3.3, 3.5), 2)
         current = round(random.uniform(0.3, 0.8), 3)
         resistance = voltage / current
-        test.measurements.current_and_voltage_over_time[timestamp, voltage] = current
+        test.measurements.current_and_voltage_over_time[timestamp,
+                                                        voltage] = current
         test.measurements.current_voltage_resistence_over_time[
             timestamp, voltage, current
         ] = resistance
@@ -84,7 +86,9 @@ def main():
     random_digits = "".join([str(random.randint(0, 9)) for _ in range(5)])
     serial_number = f"00220D4K{random_digits}"
 
-    test.add_output_callbacks(json_factory.OutputToJSON("test_result.json", indent=2))
+    test.add_output_callbacks(
+        json_factory.OutputToJSON(
+            "test_result.json", indent=2))
 
     start = time.time()
     # Execute the test

--- a/qa/openhtf/multi_measurements/main.py
+++ b/qa/openhtf/multi_measurements/main.py
@@ -1,7 +1,8 @@
+import random
+
 import openhtf as htf
 from openhtf.util import units
 from tofupilot.openhtf import TofuPilot
-import random
 
 
 @htf.measures(
@@ -23,23 +24,27 @@ def phaseresult_test():
 
 
 @htf.measures(
-    htf.Measurement("two_limits").in_range(4.5, 5).with_units(units.VOLT),
-    htf.Measurement("one_limit").in_range(maximum=1.5).with_units(units.AMPERE),
-    htf.Measurement("percentage").in_range(85, 98).with_units(units.Unit("%")),
-)
+    htf.Measurement("two_limits").in_range(
+        4.5, 5).with_units(
+            units.VOLT), htf.Measurement("one_limit").in_range(
+                maximum=1.5).with_units(
+                    units.AMPERE), htf.Measurement("percentage").in_range(
+                        85, 98).with_units(
+                            units.Unit("%")), )
 def measure_test_with_limits(test):
     test.measurements.two_limits = round(random.uniform(3.8, 4.9), 2)
     test.measurements.one_limit = round(random.uniform(1.0, 1.6), 3)
     input_power = 500
     output_power = round(random.uniform(425, 480))
-    test.measurements.percentage = round(((output_power / input_power) * 100), 1)
+    test.measurements.percentage = round(
+        ((output_power / input_power) * 100), 1)
 
 
-@htf.measures(
-    htf.Measurement("is_connected").equals(True),
-    htf.Measurement("firmware_version").equals("1.2.7"),
-    htf.Measurement("temperature").in_range(20, 25).with_units(units.DEGREE_CELSIUS),
-)
+@htf.measures(htf.Measurement("is_connected").equals(True),
+              htf.Measurement("firmware_version").equals("1.2.7"),
+              htf.Measurement("temperature").in_range(20,
+                                                      25).with_units(units.DEGREE_CELSIUS),
+              )
 def phase_multi_measurements(test):
     test.measurements.is_connected = True
     test.measurements.firmware_version = (
@@ -60,7 +65,14 @@ def dimensions(test):
     """Phase with dimensioned measurements."""
     for dim in range(5):
         test.measurements.dimensions[dim] = 1 << dim
-    for x, y, z in zip(list(range(1, 5)), list(range(21, 25)), list(range(101, 105))):
+    for x, y, z in zip(
+        list(
+            range(
+            1, 5)), list(
+                range(
+                    21, 25)), list(
+                        range(
+                            101, 105))):
         test.measurements.lots_of_dims[x, y, z] = x + y + z
 
 

--- a/qa/openhtf/procedure_version/main.py
+++ b/qa/openhtf/procedure_version/main.py
@@ -1,4 +1,5 @@
 import random
+
 import openhtf as htf
 from tofupilot.openhtf import TofuPilot
 

--- a/qa/openhtf/regex_serial_number/main.py
+++ b/qa/openhtf/regex_serial_number/main.py
@@ -1,4 +1,5 @@
 import random
+
 import openhtf as htf
 from tofupilot.openhtf import TofuPilot
 


### PR DESCRIPTION
- Fix timestamp format to use ISO-8601 with Z timezone as required by API
- Rename handler class to TofuPilotLogHandler for clarity
- Improve code organization and comments
- Add examples of different log levels
