### PR TITLE
Add touchpad positional accuracy example

### DIFF
--- a/touchpad_accuracy/README.md
+++ b/touchpad_accuracy/README.md
@@ -1,0 +1,71 @@
+# Touchpad positional accuracy
+
+A touchpad is tested by pressing it. A robot puts a known force on a known
+coordinate, and the pad reports where it thinks it was touched; the number that
+matters is the distance between the two.
+
+`touchpad_ptp/` records that distance against the Precision Touchpad linearity
+limits — **0.5 mm** across the pad, relaxed to **1.5 mm** within 3.5 mm of an
+edge, where the sensor is least linear. Windows reports these distances in
+himetric units (0.01 mm), which is what the HID read in `plugs/touch_robot.py`
+converts from.
+
+```
+touchpad_ptp/
+├── procedure.yaml          phases, measurements and limits
+├── phases/                 the Python each phase runs
+└── plugs/                  one class per instrument
+```
+
+```bash
+tofupilot run ./touchpad_ptp
+```
+
+The plugs return representative data so the procedure runs anywhere. Every
+method keeps its real call directly above, commented out — swap the two and the
+same procedure drives the bench:
+
+- `plugs/touch_robot.py` — motion controller over VISA for the press, HID
+  digitizer report for the contact the pad reported
+- `plugs/force_gauge.py` — load cell ramped until the dome switch closes,
+  triggered on the closure rather than sampled and compared afterwards
+
+## The grid is one measurement, not nine
+
+A manual test taps each target and writes down whether it looked right. Here
+each grid becomes a curve indexed by target, with `max` validated against the
+spec limit and `mean` against a tighter working limit:
+
+```yaml
+- name: Edge Positional Error
+  x_axis:
+    legend: Target
+  y_axis:
+    - legend: Error
+      unit: mm
+      aggregations:
+        - type: max
+          validators:
+            - operator: "<="
+              expected_value: 1.5
+```
+
+`max` is what fails the unit — one target outside the limit is a failure no
+average should absorb. Keeping the whole series alongside it is what separates
+a pad that is off in one corner from one that is off everywhere, which is the
+difference between a fixture problem and a sensor problem.
+
+The worst edge target is recorded a second time as a scalar, so the failing
+number is filterable on its own and trendable across a population.
+
+## Two limits, one press
+
+The central grid and the edge band run the same code against the same fixture.
+They are separate phases only because the spec allows three times the error
+inside the border strip, and a single limit would either pass a bad centre or
+fail a good edge.
+
+Click actuation force comes off the same fixture in the same cycle. It has
+nothing to do with position, but a dome that stiffens or softens is an early
+sign of the same mechanical drift that moves the positional error, and it costs
+one extra phase to catch.

--- a/touchpad_accuracy/touchpad_ptp/phases/center_linearity.py
+++ b/touchpad_accuracy/touchpad_ptp/phases/center_linearity.py
@@ -1,0 +1,37 @@
+"""The nine targets a manual test taps by hand, as one curve.
+
+Each target is a commanded coordinate; the measurement is the distance between
+it and the contact the pad reported. Keeping the whole grid as a series means a
+unit that is off in one corner is distinguishable from one that is off
+everywhere, which a single worst-case number hides.
+"""
+
+import math
+
+# 2 mm grid across the central region, clear of the edge band.
+TARGETS = (
+    (26, 16), (52, 16), (79, 16),
+    (26, 32), (52, 32), (79, 32),
+    (26, 49), (52, 49), (79, 49),
+)
+
+
+def center_linearity(measurements, robot, log):
+    index = []
+    errors = []
+
+    for n, (target_x, target_y) in enumerate(TARGETS, start=1):
+        reported_x, reported_y = robot.press(target_x, target_y)
+        error = round(math.dist((target_x, target_y), (reported_x, reported_y)), 3)
+
+        log.info(f"({target_x},{target_y}) -> ({reported_x:.2f},{reported_y:.2f}) = {error} mm")
+        index.append(n)
+        errors.append(error)
+
+    measurements.center_positional_error.x_axis = index
+    measurements.center_positional_error.y_axis.error = errors
+    # The unit passes when every target is inside the limit, not on average.
+    measurements.center_positional_error.y_axis.error.aggregations.max = max(errors)
+    measurements.center_positional_error.y_axis.error.aggregations.mean = round(
+        sum(errors) / len(errors), 3
+    )

--- a/touchpad_accuracy/touchpad_ptp/phases/click_actuation_force.py
+++ b/touchpad_accuracy/touchpad_ptp/phases/click_actuation_force.py
@@ -1,0 +1,13 @@
+"""How hard the pad has to be pressed before it clicks.
+
+Unrelated to position, but it comes off the same fixture in the same cycle, and
+a dome that stiffens or softens is an early sign of the same mechanical problem
+that moves the positional error.
+"""
+
+
+def click_actuation_force(measurements, gauge, log):
+    grams = gauge.ramp_until_actuation()
+    log.info(f"Switch actuated at {grams} g")
+
+    measurements.actuation_force = grams

--- a/touchpad_accuracy/touchpad_ptp/phases/edge_band_linearity.py
+++ b/touchpad_accuracy/touchpad_ptp/phases/edge_band_linearity.py
@@ -1,0 +1,39 @@
+"""The border, where touchpads actually fail.
+
+Same press, same measurement as the central grid, but within 3.5 mm of an edge
+the spec allows three times the error. Sampling the corners and the middle of
+each side is what catches a sensor whose linearity falls apart only at one end.
+"""
+
+import math
+
+# Targets inside the 3.5 mm border strip: four corners, four side midpoints.
+TARGETS = (
+    (2, 2), (52, 2), (103, 2),
+    (2, 32), (103, 32),
+    (2, 63), (52, 63), (103, 63),
+)
+
+
+def edge_band_linearity(measurements, robot, log):
+    index = []
+    errors = []
+
+    for n, (target_x, target_y) in enumerate(TARGETS, start=1):
+        reported_x, reported_y = robot.press(target_x, target_y)
+        error = round(math.dist((target_x, target_y), (reported_x, reported_y)), 3)
+
+        log.info(f"({target_x},{target_y}) -> ({reported_x:.2f},{reported_y:.2f}) = {error} mm")
+        index.append(n)
+        errors.append(error)
+
+    measurements.edge_positional_error.x_axis = index
+    measurements.edge_positional_error.y_axis.error = errors
+    measurements.edge_positional_error.y_axis.error.aggregations.max = max(errors)
+    measurements.edge_positional_error.y_axis.error.aggregations.mean = round(
+        sum(errors) / len(errors), 3
+    )
+
+    # Repeated as a scalar so the failing number is filterable on its own, and
+    # so drift on the worst target is trendable across a population.
+    measurements.worst_edge_error = max(errors)

--- a/touchpad_accuracy/touchpad_ptp/phases/home_fixture.py
+++ b/touchpad_accuracy/touchpad_ptp/phases/home_fixture.py
@@ -1,0 +1,12 @@
+"""Home the probe and zero the gauge before anything is measured.
+
+Positional error is only comparable across units if every press starts from the
+same reference, so this runs first and the rest depend on it implicitly.
+"""
+
+
+def home_fixture(log, robot, gauge):
+    log.info(f"Robot: {robot.identity()}")
+    log.info(f"Gauge: {gauge.identity()}")
+    gauge.zero()
+    log.info("Fixture homed and zeroed")

--- a/touchpad_accuracy/touchpad_ptp/plugs/force_gauge.py
+++ b/touchpad_accuracy/touchpad_ptp/plugs/force_gauge.py
@@ -1,0 +1,42 @@
+"""Inline load cell reading the force at which the dome switch actuates."""
+
+# Load cell indicator on the bench LAN.
+GAUGE_RESOURCE = "TCPIP0::192.0.2.21::inst0::INSTR"
+
+# Ramp until the switch reports, or give up.
+RAMP_LIMIT_G = 120.0
+
+import random
+
+
+class ForceGauge:
+    def __init__(self):
+        self._gauge = None
+
+        # import pyvisa
+        #
+        # self._gauge = pyvisa.ResourceManager().open_resource(GAUGE_RESOURCE)
+        # self._gauge.timeout = 10_000
+        # self._gauge.write("UNIT:FORCe GRAM")
+
+    def __del__(self):
+        pass
+
+    def identity(self) -> str:
+        # return self._gauge.query("*IDN?").strip()
+        return "SIMULATED-LOAD-CELL,1.0"
+
+    def zero(self) -> None:
+        # self._gauge.write("SENSe:CORRection:COLLect:ZERO")
+        # self._gauge.query("*OPC?")
+        pass
+
+    def ramp_until_actuation(self) -> float:
+        """Ramp force at the pad centre; return the force at the click, in grams."""
+        # The switch closure is what stops the ramp, so the gauge is read on
+        # the edge rather than sampled and compared afterwards.
+        # self._gauge.write(f"SOURce:FORCe:RAMP {RAMP_LIMIT_G}")
+        # self._gauge.write("TRIGger:SOURce EXTernal")
+        # return float(self._gauge.query("FETCh:FORCe?"))
+
+        return round(random.gauss(60.5, 3.4), 1)

--- a/touchpad_accuracy/touchpad_ptp/plugs/touch_robot.py
+++ b/touchpad_accuracy/touchpad_ptp/plugs/touch_robot.py
@@ -1,0 +1,71 @@
+"""Cartesian probe pressing a calibrated force at a commanded x/y target.
+
+Two halves on a real bench: the motion controller that puts the tip somewhere,
+and the HID read that says where the pad thought it was touched. The positional
+error is the distance between the two, so both have to come from the same press.
+"""
+
+# Motion controller on the bench LAN.
+ROBOT_RESOURCE = "TCPIP0::192.0.2.20::inst0::INSTR"
+
+# Pad geometry, mm. The border strip where the spec relaxes its limit.
+PAD_W, PAD_H = 105.0, 65.0
+EDGE_BAND = 3.5
+
+# Probe force held constant across the grid so error stays comparable.
+PROBE_FORCE_G = 60.0
+
+import random
+
+
+class TouchRobot:
+    def __init__(self):
+        self._axes = None
+        self._hid = None
+
+        # import pyvisa
+        # import hid
+        #
+        # self._axes = pyvisa.ResourceManager().open_resource(ROBOT_RESOURCE)
+        # self._axes.timeout = 10_000
+        # self._axes.write("HOME")
+        # self._axes.query("*OPC?")
+        # self._axes.write(f"FORCe {PROBE_FORCE_G}")
+        #
+        # # The pad under test, as the OS sees it.
+        # self._hid = hid.Device(vid=0x0000, pid=0x0000)
+
+    def __del__(self):
+        # self._axes.write("PARK")
+        pass
+
+    def identity(self) -> str:
+        # return self._axes.query("*IDN?").strip()
+        return "SIMULATED-XY-STAGE,1.0"
+
+    def in_edge_band(self, x: float, y: float) -> bool:
+        return (
+            x < EDGE_BAND
+            or y < EDGE_BAND
+            or x > PAD_W - EDGE_BAND
+            or y > PAD_H - EDGE_BAND
+        )
+
+    def press(self, x: float, y: float) -> tuple[float, float]:
+        """Press at a commanded target; return the contact the pad reported."""
+        # self._axes.write(f"MOVE {x:.3f} {y:.3f}")
+        # self._axes.query("*OPC?")
+        # self._axes.write("PRESS")
+        # self._axes.query("*OPC?")
+        #
+        # # Digitizer report: absolute X/Y in himetric (0.01 mm), the unit the
+        # # Precision Touchpad tests report distances in.
+        # report = self._hid.read(64, timeout=1000)
+        # reported_x = int.from_bytes(report[2:4], "little") / 100.0
+        # reported_y = int.from_bytes(report[4:6], "little") / 100.0
+        # return reported_x, reported_y
+
+        # Simulated: the sensor is markedly less linear near the border, which
+        # is the whole reason the spec carries two limits.
+        sigma = 0.42 if self.in_edge_band(x, y) else 0.14
+        return x + random.gauss(0.0, sigma), y + random.gauss(0.0, sigma)

--- a/touchpad_accuracy/touchpad_ptp/procedure.yaml
+++ b/touchpad_accuracy/touchpad_ptp/procedure.yaml
@@ -1,0 +1,89 @@
+name: Touchpad Positional Accuracy
+version: 1.0.0
+
+unit:
+  auto_identify: true
+  serial_number:
+    default_value: "SN-0001"
+  part_number:
+    default_value: "TPAD-REV-A"
+
+plugs:
+  - key: robot
+    name: Touch Robot
+    python: plugs.touch_robot:TouchRobot
+  - key: gauge
+    name: Force Gauge
+    python: plugs.force_gauge:ForceGauge
+
+main:
+  - name: Home Fixture
+    key: home_fixture
+    python: phases.home_fixture
+
+  # Every press is referenced to the homed position, so the grid phases wait
+  # for it rather than racing it.
+  - name: Center Linearity
+    python: phases.center_linearity
+    depends_on:
+      - home_fixture
+    measurements:
+      # Precision Touchpad linearity: 0.5 mm edge to edge, away from the border.
+      - name: Center Positional Error
+        title: Positional error across the central region
+        x_axis:
+          legend: Target
+        y_axis:
+          - legend: Error
+            unit: mm
+            aggregations:
+              - type: max
+                validators:
+                  - operator: "<="
+                    expected_value: 0.5
+              - type: mean
+                validators:
+                  - operator: "<="
+                    expected_value: 0.35
+
+  - name: Edge Band Linearity
+    python: phases.edge_band_linearity
+    depends_on:
+      - home_fixture
+    measurements:
+      # Within 3.5 mm of an edge the same spec relaxes to 1.5 mm.
+      - name: Edge Positional Error
+        title: Positional error along the 3.5 mm edge band
+        x_axis:
+          legend: Target
+        y_axis:
+          - legend: Error
+            unit: mm
+            aggregations:
+              - type: max
+                validators:
+                  - operator: "<="
+                    expected_value: 1.5
+              - type: mean
+                validators:
+                  - operator: "<="
+                    expected_value: 1.1
+      # The worst single target is what fails a unit, so it is kept on its own.
+      - name: Worst Edge Error
+        unit: mm
+        validators:
+          - operator: "<="
+            expected_value: 1.5
+
+  - name: Click Actuation Force
+    python: phases.click_actuation_force
+    depends_on:
+      - home_fixture
+    measurements:
+      - name: Actuation Force
+        unit: g
+        validators:
+          - operator: ">="
+            expected_value: 50
+          - operator: "<="
+            expected_value: 70


### PR DESCRIPTION
A touchpad is tested by pressing it: a robot puts a known force on a known coordinate, and the pad reports where it thinks it was touched. The number that matters is the distance between the two.

`touchpad_ptp/` records that distance against the Precision Touchpad linearity limits — 0.5 mm across the pad, relaxed to 1.5 mm within 3.5 mm of an edge, where the sensor is least linear. Windows reports these distances in himetric units (0.01 mm), which is what the HID read in `plugs/touch_robot.py` converts from.

## The grid is one measurement, not nine

A manual test taps each target and writes down whether it looked right. Here each grid becomes a curve indexed by target, with `max` validated against the spec limit and `mean` against a tighter working limit.

`max` is what fails the unit — one target outside the limit is a failure no average should absorb. Keeping the whole series alongside it separates a pad that is off in one corner from one that is off everywhere, which is the difference between a fixture problem and a sensor problem. The worst edge target is recorded a second time as a scalar, so the failing number is filterable on its own and trendable across a population.

## Two limits, one press

The central grid and the edge band run the same code against the same fixture. They are separate phases only because the spec allows three times the error inside the border strip, and a single limit would either pass a bad centre or fail a good edge.

Click actuation force comes off the same fixture in the same cycle. It has nothing to do with position, but a dome that stiffens or softens is an early sign of the same mechanical drift that moves the positional error.

Plugs return representative data so the procedure runs anywhere; each method keeps its real call commented directly above — motion controller over VISA for the press, HID digitizer report for the reported contact, load cell triggered on switch closure for the click.

Verified with `tofupilot run ./touchpad_ptp` — all four phases PASS, aggregation validators firing with computed values.